### PR TITLE
fixed getRootException infinite loop

### DIFF
--- a/src/main/java/de/siegmar/logbackgelf/GelfLayout.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfLayout.java
@@ -334,7 +334,7 @@ public class GelfLayout extends LayoutBase<ILoggingEvent> {
 
         IThrowableProxy rootCause = throwableProxy;
         while (rootCause.getCause() != null) {
-            rootCause = throwableProxy.getCause();
+            rootCause = rootCause.getCause();
         }
 
         return rootCause;

--- a/src/test/java/de/siegmar/logbackgelf/GelfLayoutTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfLayoutTest.java
@@ -73,6 +73,19 @@ public class GelfLayoutTest {
         assertEquals("message 1", msg.readLine());
     }
 
+    @Test(timeout = 400L)
+    public void nestedExceptionShouldNotFail() {
+        layout.setIncludeRootCauseData(true);
+        layout.start();
+
+        final LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        final Logger logger = lc.getLogger(LOGGER_NAME);
+
+        final String logMsg = layout.doLayout(simpleLoggingEvent(logger, new IOException(new IOException(new IOException()))));
+
+        assertNotNull(logMsg);
+    }
+
     private LoggingEvent simpleLoggingEvent(final Logger logger, final Throwable e) {
         return new LoggingEvent(
             LOGGER_NAME,


### PR DESCRIPTION
Fixes nasty issue which caused 100% CPU utilization.
Please see nestedExceptionShouldNotFail unit test for explanation. That test will fail in 1.0.1 version of logback-gelf