### PR TITLE
Supporting Arrays for StaticFields

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Advanced TCP with TLS configuration:
             <staticField>os_arch:${os.arch}</staticField>
             <staticField>os_name:${os.name}</staticField>
             <staticField>os_version:${os.version}</staticField>
+            <staticField>tags:[tag01,tag02,tag03]</staticField>
         </layout>
     </appender>
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip

--- a/src/main/java/de/siegmar/logbackgelf/GelfLayout.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfLayout.java
@@ -215,7 +215,11 @@ public class GelfLayout extends LayoutBase<ILoggingEvent> {
             addWarn("staticField key '" + key + "' is illegal. "
                 + "Keys must apply to regex ^[\\w.-]*$");
         } else {
-            dst.put(key, value);
+            if (value.startsWith("[")) {
+                dst.put(key, value.substring(1, value.trim().length() - 1).split(","));
+            } else {
+                dst.put(key, value);
+            }
         }
     }
 

--- a/src/main/java/de/siegmar/logbackgelf/SimpleJsonEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/SimpleJsonEncoder.java
@@ -25,6 +25,8 @@ package de.siegmar.logbackgelf;
 class SimpleJsonEncoder {
 
     private static final char QUOTE = '"';
+    private static final String COMMA = ",";
+    private static final String EMPTY = "";
 
     /**
      * Internal buffer.
@@ -58,6 +60,14 @@ class SimpleJsonEncoder {
             appendKey(key);
             if (value instanceof Number) {
                 sb.append(value.toString());
+            } else if (value instanceof String[]) {
+                final String[] values = (String[]) value;
+                sb.append("[");
+                for (int i = 0; i < values.length; i++) {
+                    final String endChar = i < values.length - 1 ? COMMA : EMPTY;
+                    sb.append(QUOTE).append(escapeString(values[i])).append(QUOTE).append(endChar);
+                }
+                sb.append("]");
             } else {
                 sb.append(QUOTE).append(escapeString(value.toString())).append(QUOTE);
             }

--- a/src/test/java/de/siegmar/logbackgelf/SimpleJsonEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/SimpleJsonEncoderTest.java
@@ -94,6 +94,12 @@ public class SimpleJsonEncoderTest {
     }
 
     @Test
+    public void array() {
+        enc.appendToJSON("array", new String[] {"value1","value2"});
+        assertEquals("{\"array\":[\"value1\",\"value2\"]}", enc.toString());
+    }
+
+    @Test
     @SuppressWarnings("checkstyle:avoidescapedunicodecharacters")
     public void unicode() {
         enc.appendToJSON("\u0002", "\u0007\u0019");

--- a/src/test/java/de/siegmar/logbackgelf/SimpleJsonEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/SimpleJsonEncoderTest.java
@@ -95,7 +95,7 @@ public class SimpleJsonEncoderTest {
 
     @Test
     public void array() {
-        enc.appendToJSON("array", new String[] {"value1","value2"});
+        enc.appendToJSON("array", new String[] {"value1", "value2"});
         assertEquals("{\"array\":[\"value1\",\"value2\"]}", enc.toString());
     }
 


### PR DESCRIPTION
### Adding support to arrays on staticFields.

There is a feature requested for my team and other teams in my company that we need to send an array on staticFields.

On our example, we are using a staticField called `tags`, and we send a list of values that our _logstash_ is indexing.

For example:
```xml
<staticField>tags:[team,app,environment]</staticField>
```
is going to be transformed to:
```json
"tags": [
      "team",
      "app",
      "environment"
    ]
```
