### PR TITLE
log configured values as integer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = "de.siegmar"
 archivesBaseName = "logback-gelf"
-version = "2.0.1"
+version = "2.1.0"
 
 sourceCompatibility = 1.7
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 group = "de.siegmar"
 archivesBaseName = "logback-gelf"
-version = "2.1.0"
+version = "2.0.1"
 
 sourceCompatibility = 1.7
 

--- a/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
@@ -24,10 +24,8 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.slf4j.Marker;
@@ -105,7 +103,7 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
      */
     private PatternLayout fullPatternLayout;
 
-    private Set<String> integerFields = new HashSet<>();
+    private boolean numbersAsString = true;
 
     /**
      * Additional, static fields to send to graylog. Defaults: none.
@@ -176,16 +174,12 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
         this.appendNewline = appendNewline;
     }
 
-    public Set<String> getIntegerFields() {
-        return integerFields;
+    public boolean isNumbersAsString() {
+        return numbersAsString;
     }
 
-    public void setIntegerFields(final Set<String> integerFields) {
-        this.integerFields = integerFields;
-    }
-
-    public void addIntegerField(final String field) {
-        integerFields.add(field);
+    public void setNumbersAsString(final boolean numbersAsString) {
+        this.numbersAsString = numbersAsString;
     }
 
     public PatternLayout getShortPatternLayout() {
@@ -240,12 +234,12 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
     }
 
     private Object processValue(final String key, final String value) {
-        if (integerFields.contains(key)) {
-            if (value.matches("\\d+")) {
-                return Long.parseLong(value);
+        if (!numbersAsString) {
+            try {
+                return Double.valueOf(value);
+            } catch (final NumberFormatException e) {
+                return value;
             }
-            addWarn("field with key '" + key + "' has no valid integer value '" + value + "'");
-            return null;
         }
         return value;
     }

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 
-import com.google.common.collect.Sets;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.LoggerFactory;
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import com.google.common.io.LineReader;
 
 import ch.qos.logback.classic.Level;


### PR DESCRIPTION
If you want to filter in Kibana with a range (example all requests with HTTP status code 200 to 299), the indexed field must be a numeric value and not a string. Now you're able to configure "intergerFields" in your logback configuration.
