### PR TITLE
Allow encoder subclasses to customize the message before it is converted to String

### DIFF
--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -6,5 +6,6 @@
 
     <suppress files=".*Test.java" checks="MagicNumber"/>
     <suppress files=".*Test.java" checks="ImportControl"/>
+    <suppress files="CustomGelfEncoder.java" checks="ImportControl"/>
 
 </suppressions>

--- a/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
@@ -306,12 +306,19 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
             new GelfMessage(originHost, shortMessage, fullMessage, timestamp,
                 LevelToSyslogSeverity.convert(event), additionalFields);
 
-        String jsonStr = gelfMessage.toJSON();
+        String jsonStr = gelfMessageToJson(gelfMessage);
         if (appendNewline) {
             jsonStr += System.lineSeparator();
         }
 
         return jsonStr.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Allow subclasses to customize the message before it is converted to String.
+     */
+    protected String gelfMessageToJson(final GelfMessage gelfMessage) {
+        return gelfMessage.toJSON();
     }
 
     @Override

--- a/src/main/java/de/siegmar/logbackgelf/GelfMessage.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfMessage.java
@@ -72,4 +72,28 @@ class GelfMessage {
         return jsonEncoder.toString();
     }
 
+    public String getHost() {
+        return host;
+    }
+
+    public String getShortMessage() {
+        return shortMessage;
+    }
+
+    public String getFullMessage() {
+        return fullMessage;
+    }
+
+    public double getTimestamp() {
+        return timestamp;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public Map<String, Object> getAdditionalFields() {
+        return additionalFields;
+    }
+
 }

--- a/src/main/java/de/siegmar/logbackgelf/GelfMessage.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfMessage.java
@@ -28,7 +28,7 @@ import java.util.Objects;
 /**
  * Class for GELF 1.1 format representation.
  */
-class GelfMessage {
+public class GelfMessage {
 
     private static final String VERSION = "1.1";
 

--- a/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
@@ -1,3 +1,22 @@
+/*
+ * Logback GELF - zero dependencies Logback GELF appender library.
+ * Copyright (C) 2016 Oliver Siegmar
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package de.siegmar.logbackgelf;
 
 import ch.qos.logback.classic.Logger;

--- a/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
@@ -19,22 +19,26 @@
 
 package de.siegmar.logbackgelf;
 
-import ch.qos.logback.classic.Logger;
-import ch.qos.logback.classic.LoggerContext;
-import ch.qos.logback.classic.spi.LoggingEvent;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import de.siegmar.logbackgelf.custom.CustomGelfEncoder;
-import org.junit.Before;
-import org.junit.Test;
-import org.slf4j.LoggerFactory;
+import static org.junit.Assert.assertEquals;
+
+import static de.siegmar.logbackgelf.GelfEncoderTest.basicValidation;
+import static de.siegmar.logbackgelf.GelfEncoderTest.simpleLoggingEvent;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
-import static de.siegmar.logbackgelf.GelfEncoderTest.basicValidation;
-import static de.siegmar.logbackgelf.GelfEncoderTest.simpleLoggingEvent;
-import static org.junit.Assert.assertEquals;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+
+import de.siegmar.logbackgelf.custom.CustomGelfEncoder;
 
 public class CustomGelfEncoderTest {
 

--- a/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
@@ -20,7 +20,6 @@
 package de.siegmar.logbackgelf;
 
 import static org.junit.Assert.assertEquals;
-
 import static de.siegmar.logbackgelf.GelfEncoderTest.basicValidation;
 import static de.siegmar.logbackgelf.GelfEncoderTest.simpleLoggingEvent;
 
@@ -37,7 +36,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.LoggingEvent;
-
 import de.siegmar.logbackgelf.custom.CustomGelfEncoder;
 
 public class CustomGelfEncoderTest {

--- a/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
@@ -38,43 +38,43 @@ import static org.junit.Assert.assertEquals;
 
 public class CustomGelfEncoderTest {
 
-  private static final String LOGGER_NAME = GelfEncoderTest.class.getCanonicalName();
-  private static final String THREAD_NAME = "thread name";
-  private static final long TIMESTAMP = 1577359700000L;
+    private static final String LOGGER_NAME = GelfEncoderTest.class.getCanonicalName();
+    private static final String THREAD_NAME = "thread name";
+    private static final long TIMESTAMP = 1577359700000L;
 
-  private final CustomGelfEncoder encoder = new CustomGelfEncoder();
+    private final CustomGelfEncoder encoder = new CustomGelfEncoder();
 
-  @Before
-  public void before() {
-    encoder.setContext(new LoggerContext());
-    encoder.setOriginHost("localhost");
-  }
+    @Before
+    public void before() {
+        encoder.setContext(new LoggerContext());
+        encoder.setOriginHost("localhost");
+    }
 
-  @Test
-  public void custom() throws IOException {
-    encoder.start();
+    @Test
+    public void custom() throws IOException {
+        encoder.start();
 
-    final LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
-    final Logger logger = lc.getLogger(LOGGER_NAME);
+        final LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+        final Logger logger = lc.getLogger(LOGGER_NAME);
 
-    final LoggingEvent event = simpleLoggingEvent(logger, null);
-    event.setTimeStamp(TIMESTAMP);
-    event.setThreadName(THREAD_NAME);
-    final String logMsg = encodeToStr(event);
+        final LoggingEvent event = simpleLoggingEvent(logger, null);
+        event.setTimeStamp(TIMESTAMP);
+        event.setThreadName(THREAD_NAME);
+        final String logMsg = encodeToStr(event);
 
-    final ObjectMapper om = new ObjectMapper();
-    final JsonNode jsonNode = om.readTree(logMsg);
-    basicValidation(jsonNode);
+        final ObjectMapper om = new ObjectMapper();
+        final JsonNode jsonNode = om.readTree(logMsg);
+        basicValidation(jsonNode);
 
-    assertEquals("message 1\n", jsonNode.get("full_message").textValue());
-    assertEquals("Log line: " + logMsg,
-        "970db79831490f2e5e02b80cf484308bf77e7353f727b6fd42417b82be254419",
-        jsonNode.get("_sha256").textValue()
-    );
-  }
+        assertEquals("message 1\n", jsonNode.get("full_message").textValue());
+        assertEquals("Log line: " + logMsg,
+            "970db79831490f2e5e02b80cf484308bf77e7353f727b6fd42417b82be254419",
+            jsonNode.get("_sha256").textValue()
+        );
+    }
 
-  private String encodeToStr(final LoggingEvent event) {
-    return new String(encoder.encode(event), StandardCharsets.UTF_8);
-  }
+    private String encodeToStr(final LoggingEvent event) {
+        return new String(encoder.encode(event), StandardCharsets.UTF_8);
+    }
 
 }

--- a/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertEquals;
 public class CustomGelfEncoderTest {
 
   private static final String LOGGER_NAME = GelfEncoderTest.class.getCanonicalName();
+  private static final String THREAD_NAME = "thread name";
   private static final long TIMESTAMP = 1577359700000L;
 
   private final CustomGelfEncoder encoder = new CustomGelfEncoder();
@@ -39,6 +40,7 @@ public class CustomGelfEncoderTest {
 
     final LoggingEvent event = simpleLoggingEvent(logger, null);
     event.setTimeStamp(TIMESTAMP);
+    event.setThreadName(THREAD_NAME);
     final String logMsg = encodeToStr(event);
 
     final ObjectMapper om = new ObjectMapper();
@@ -46,8 +48,8 @@ public class CustomGelfEncoderTest {
     basicValidation(jsonNode);
 
     assertEquals("message 1\n", jsonNode.get("full_message").textValue());
-    assertEquals(
-        "42d545b39843028e578fd8c2b2470b905586c028c6eb0ed218ec1dc6ea869ed3",
+    assertEquals("Log line: " + logMsg,
+        "970db79831490f2e5e02b80cf484308bf77e7353f727b6fd42417b82be254419",
         jsonNode.get("_sha256").textValue()
     );
   }

--- a/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/CustomGelfEncoderTest.java
@@ -1,0 +1,59 @@
+package de.siegmar.logbackgelf;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import de.siegmar.logbackgelf.custom.CustomGelfEncoder;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static de.siegmar.logbackgelf.GelfEncoderTest.basicValidation;
+import static de.siegmar.logbackgelf.GelfEncoderTest.simpleLoggingEvent;
+import static org.junit.Assert.assertEquals;
+
+public class CustomGelfEncoderTest {
+
+  private static final String LOGGER_NAME = GelfEncoderTest.class.getCanonicalName();
+  private static final long TIMESTAMP = 1577359700000L;
+
+  private final CustomGelfEncoder encoder = new CustomGelfEncoder();
+
+  @Before
+  public void before() {
+    encoder.setContext(new LoggerContext());
+    encoder.setOriginHost("localhost");
+  }
+
+  @Test
+  public void custom() throws IOException {
+    encoder.start();
+
+    final LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+    final Logger logger = lc.getLogger(LOGGER_NAME);
+
+    final LoggingEvent event = simpleLoggingEvent(logger, null);
+    event.setTimeStamp(TIMESTAMP);
+    final String logMsg = encodeToStr(event);
+
+    final ObjectMapper om = new ObjectMapper();
+    final JsonNode jsonNode = om.readTree(logMsg);
+    basicValidation(jsonNode);
+
+    assertEquals("message 1\n", jsonNode.get("full_message").textValue());
+    assertEquals(
+        "42d545b39843028e578fd8c2b2470b905586c028c6eb0ed218ec1dc6ea869ed3",
+        jsonNode.get("_sha256").textValue()
+    );
+  }
+
+  private String encodeToStr(final LoggingEvent event) {
+    return new String(encoder.encode(event), StandardCharsets.UTF_8);
+  }
+
+}

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -100,7 +100,7 @@ public class GelfEncoderTest {
         assertNotNull(logMsg);
     }
 
-    private LoggingEvent simpleLoggingEvent(final Logger logger, final Throwable e) {
+    static LoggingEvent simpleLoggingEvent(final Logger logger, final Throwable e) {
         return new LoggingEvent(
             LOGGER_NAME,
             logger,
@@ -110,7 +110,7 @@ public class GelfEncoderTest {
             new Object[]{1});
     }
 
-    private void basicValidation(final JsonNode jsonNode) {
+    static void basicValidation(final JsonNode jsonNode) {
         assertEquals("1.1", jsonNode.get("version").textValue());
         assertEquals("localhost", jsonNode.get("host").textValue());
         assertEquals("message 1", jsonNode.get("short_message").textValue());

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -100,7 +100,7 @@ public class GelfEncoderTest {
         assertNotNull(logMsg);
     }
 
-    static LoggingEvent simpleLoggingEvent(final Logger logger, final Throwable e) {
+    public static LoggingEvent simpleLoggingEvent(final Logger logger, final Throwable e) {
         return new LoggingEvent(
             LOGGER_NAME,
             logger,
@@ -110,7 +110,7 @@ public class GelfEncoderTest {
             new Object[]{1});
     }
 
-    static void basicValidation(final JsonNode jsonNode) {
+    public static void basicValidation(final JsonNode jsonNode) {
         assertEquals("1.1", jsonNode.get("version").textValue());
         assertEquals("localhost", jsonNode.get("host").textValue());
         assertEquals("message 1", jsonNode.get("short_message").textValue());

--- a/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
+++ b/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
@@ -1,0 +1,20 @@
+package de.siegmar.logbackgelf.custom;
+
+import com.google.common.hash.Hashing;
+import de.siegmar.logbackgelf.GelfEncoder;
+import de.siegmar.logbackgelf.GelfMessage;
+
+import java.nio.charset.StandardCharsets;
+
+// Put it in different package from GelfEncoder to reveal any visibility issues
+public class CustomGelfEncoder extends GelfEncoder {
+
+  @Override
+  protected String gelfMessageToJson(GelfMessage gelfMessage) {
+    String json = super.gelfMessageToJson(gelfMessage);
+    String sha256 = Hashing.sha256().hashString(json, StandardCharsets.UTF_8).toString();
+    gelfMessage.getAdditionalFields().put("sha256", sha256);
+    return super.gelfMessageToJson(gelfMessage);
+  }
+
+}

--- a/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
+++ b/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
@@ -1,3 +1,22 @@
+/*
+ * Logback GELF - zero dependencies Logback GELF appender library.
+ * Copyright (C) 2016 Oliver Siegmar
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 package de.siegmar.logbackgelf.custom;
 
 import com.google.common.hash.Hashing;

--- a/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
+++ b/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
@@ -21,12 +21,16 @@ package de.siegmar.logbackgelf.custom;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import de.siegmar.logbackgelf.GelfEncoder;
 import de.siegmar.logbackgelf.GelfMessage;
 
 // Put it in different package from GelfEncoder to reveal any visibility issues
 public class CustomGelfEncoder extends GelfEncoder {
+
+    private static final int INT_255 = 0xff;
+    private static final char CHAR_ZERO = '0';
 
     @Override
     protected String gelfMessageToJson(final GelfMessage gelfMessage) {
@@ -44,14 +48,15 @@ public class CustomGelfEncoder extends GelfEncoder {
             final StringBuilder hexString = new StringBuilder();
 
             for (byte b : hash) {
-                final String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) hexString.append('0');
+                final String hex = Integer.toHexString(INT_255 & b);
+                if (hex.length() == 1) {
+                    hexString.append(CHAR_ZERO);
+                }
                 hexString.append(hex);
             }
 
             return hexString.toString();
-        }
-        catch (Exception e) {
+        } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }
     }

--- a/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
+++ b/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
@@ -20,8 +20,8 @@
 package de.siegmar.logbackgelf.custom;
 
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
+
+import com.google.common.hash.Hashing;
 
 import de.siegmar.logbackgelf.GelfEncoder;
 import de.siegmar.logbackgelf.GelfMessage;
@@ -29,36 +29,12 @@ import de.siegmar.logbackgelf.GelfMessage;
 // Put it in different package from GelfEncoder to reveal any visibility issues
 public class CustomGelfEncoder extends GelfEncoder {
 
-    private static final int INT_255 = 0xff;
-    private static final char CHAR_ZERO = '0';
-
     @Override
     protected String gelfMessageToJson(final GelfMessage gelfMessage) {
         final String json = super.gelfMessageToJson(gelfMessage);
-        final String sha256 = sha256(json);
+        final String sha256 = Hashing.sha256().hashString(json, StandardCharsets.UTF_8).toString();
         gelfMessage.getAdditionalFields().put("sha256", sha256);
         return super.gelfMessageToJson(gelfMessage);
-    }
-
-    // Based on https://stackoverflow.com/a/11009612/74694
-    private static String sha256(final String base) {
-        try {
-            final MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            final byte[] hash = digest.digest(base.getBytes(StandardCharsets.UTF_8));
-            final StringBuilder hexString = new StringBuilder();
-
-            for (byte b : hash) {
-                final String hex = Integer.toHexString(INT_255 & b);
-                if (hex.length() == 1) {
-                    hexString.append(CHAR_ZERO);
-                }
-                hexString.append(hex);
-            }
-
-            return hexString.toString();
-        } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException(e);
-        }
     }
 
 }

--- a/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
+++ b/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
@@ -19,19 +19,20 @@
 
 package de.siegmar.logbackgelf.custom;
 
+import java.nio.charset.StandardCharsets;
+
 import com.google.common.hash.Hashing;
+
 import de.siegmar.logbackgelf.GelfEncoder;
 import de.siegmar.logbackgelf.GelfMessage;
-
-import java.nio.charset.StandardCharsets;
 
 // Put it in different package from GelfEncoder to reveal any visibility issues
 public class CustomGelfEncoder extends GelfEncoder {
 
     @Override
     protected String gelfMessageToJson(GelfMessage gelfMessage) {
-        String json = super.gelfMessageToJson(gelfMessage);
-        String sha256 = Hashing.sha256().hashString(json, StandardCharsets.UTF_8).toString();
+        final String json = super.gelfMessageToJson(gelfMessage);
+        final String sha256 = Hashing.sha256().hashString(json, StandardCharsets.UTF_8).toString();
         gelfMessage.getAdditionalFields().put("sha256", sha256);
         return super.gelfMessageToJson(gelfMessage);
     }

--- a/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
+++ b/src/test/java/de/siegmar/logbackgelf/custom/CustomGelfEncoder.java
@@ -28,12 +28,12 @@ import java.nio.charset.StandardCharsets;
 // Put it in different package from GelfEncoder to reveal any visibility issues
 public class CustomGelfEncoder extends GelfEncoder {
 
-  @Override
-  protected String gelfMessageToJson(GelfMessage gelfMessage) {
-    String json = super.gelfMessageToJson(gelfMessage);
-    String sha256 = Hashing.sha256().hashString(json, StandardCharsets.UTF_8).toString();
-    gelfMessage.getAdditionalFields().put("sha256", sha256);
-    return super.gelfMessageToJson(gelfMessage);
-  }
+    @Override
+    protected String gelfMessageToJson(GelfMessage gelfMessage) {
+        String json = super.gelfMessageToJson(gelfMessage);
+        String sha256 = Hashing.sha256().hashString(json, StandardCharsets.UTF_8).toString();
+        gelfMessage.getAdditionalFields().put("sha256", sha256);
+        return super.gelfMessageToJson(gelfMessage);
+    }
 
 }


### PR DESCRIPTION
Fix for issue #39 