### PR TITLE
Makes a message attributes available as additional fields

### DIFF
--- a/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
@@ -21,12 +21,14 @@ package de.siegmar.logbackgelf;
 
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.slf4j.Marker;
 
@@ -382,6 +384,13 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
 
         if (includeRootCauseData) {
             additionalFields.putAll(buildRootExceptionData(event.getThrowableProxy()));
+        }
+
+        if (event.getArgumentArray() != null) {
+            additionalFields.putAll(Arrays.stream(event.getArgumentArray())
+                    .filter(arg -> arg instanceof StructuredArgs)
+                    .map(o -> (StructuredArgs) o)
+                    .collect(Collectors.toMap(StructuredArgs::getKey, StructuredArgs::getObject)));
         }
 
         return additionalFields;

--- a/src/main/java/de/siegmar/logbackgelf/StructuredArgs.java
+++ b/src/main/java/de/siegmar/logbackgelf/StructuredArgs.java
@@ -1,0 +1,62 @@
+/*
+ * Logback GELF - zero dependencies Logback GELF appender library.
+ * Copyright (C) 2016 Oliver Siegmar
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package de.siegmar.logbackgelf;
+
+/**
+ * This class is responsible for read structured arguments.
+ */
+public class StructuredArgs {
+
+    /**
+     * Argument key.
+     */
+    private final String key;
+
+    /**
+     * Argument value.
+     */
+    private final Object object;
+
+    public StructuredArgs(final String key, final Object object) {
+        this.key = key;
+        this.object = object;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public Object getObject() {
+        return object;
+    }
+
+    public static StructuredArgs value(final String key, final Object value) {
+        return new StructuredArgs(key, value);
+    }
+
+    public static StructuredArgs kv(final String key, final Object value) {
+        return value(key, value);
+    }
+
+    @Override
+    public String toString() {
+        return object.toString();
+    }
+}

--- a/src/main/java/de/siegmar/logbackgelf/StructuredArgs.java
+++ b/src/main/java/de/siegmar/logbackgelf/StructuredArgs.java
@@ -22,7 +22,7 @@ package de.siegmar.logbackgelf;
 /**
  * This class is responsible for read structured arguments.
  */
-public class StructuredArgs {
+public final class StructuredArgs {
 
     /**
      * Argument key.
@@ -34,7 +34,7 @@ public class StructuredArgs {
      */
     private final Object object;
 
-    public StructuredArgs(final String key, final Object object) {
+    private StructuredArgs(final String key, final Object object) {
         this.key = key;
         this.object = object;
     }


### PR DESCRIPTION
The purpose here is making message arguments as part of additional fields. 
Example: 
`log.info("message with param {}", StructuredArgs.value("fieldKey", "parameter value"));`