### PR TITLE
Add poolMaxIdleTime configuration option to TCP appenders

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ Find more advanced examples in the [examples directory](examples).
 * **poolSize**: Number of concurrent tcp connections (minimum 1). Default: 2.
 * **poolMaxWaitTime**: Maximum amount of time (in milliseconds) to wait for a connection to become
   available from the pool. A value of -1 disables the timeout. Default: 5,000 milliseconds.
-
+* **poolMaxIdleTime**: Maximum amount of time (in seconds) that a pooled connection can be idle
+  before it is considered 'stale' and will not be reused. A value of -1 disables the max idle time
+  feature. Default: -1 (disabled).
 
 `de.siegmar.logbackgelf.GelfTcpTlsAppender`
 

--- a/examples/advanced_tcp.xml
+++ b/examples/advanced_tcp.xml
@@ -9,6 +9,7 @@
         <retryDelay>3000</retryDelay>
         <poolSize>2</poolSize>
         <poolMaxWaitTime>5000</poolMaxWaitTime>
+        <poolMaxIdleTime>10</poolMaxIdleTime>
         <encoder class="de.siegmar.logbackgelf.GelfEncoder">
             <originHost>localhost</originHost>
             <includeRawMessage>false</includeRawMessage>

--- a/src/main/java/de/siegmar/logbackgelf/GelfTcpAppender.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfTcpAppender.java
@@ -31,6 +31,7 @@ public class GelfTcpAppender extends AbstractGelfAppender {
     private static final int DEFAULT_RETRY_DELAY = 3_000;
     private static final int DEFAULT_POOL_SIZE = 2;
     private static final int DEFAULT_POOL_MAX_WAIT_TIME = 5_000;
+    private static final int DEFAULT_POOL_MAX_IDLE_TIME = -1;
 
     /**
      * Maximum time (in milliseconds) to wait for establishing a connection. A value of 0 disables
@@ -65,6 +66,13 @@ public class GelfTcpAppender extends AbstractGelfAppender {
      * available from the pool. A value of -1 disables the timeout. Default: 5,000 milliseconds.
      */
     private int poolMaxWaitTime = DEFAULT_POOL_MAX_WAIT_TIME;
+
+    /**
+     * Maximum amount of time (in seconds) that a pooled connection can be idle before it is
+     * considered 'stale' and will not be reused. A value of -1 disables the max idle time feature.
+     * Default: -1 (disabled).
+     */
+    private int poolMaxIdleTime = DEFAULT_POOL_MAX_IDLE_TIME;
 
     private SimpleObjectPool<TcpConnection> connectionPool;
 
@@ -121,7 +129,7 @@ public class GelfTcpAppender extends AbstractGelfAppender {
 
         connectionPool = new SimpleObjectPool<>(() -> new TcpConnection(initSocketFactory(),
             addressResolver, getGraylogPort(), connectTimeout),
-            poolSize, poolMaxWaitTime, reconnectInterval);
+            poolSize, poolMaxWaitTime, reconnectInterval, poolMaxIdleTime);
     }
 
     protected SocketFactory initSocketFactory() {

--- a/src/main/java/de/siegmar/logbackgelf/pool/AbstractPooledObject.java
+++ b/src/main/java/de/siegmar/logbackgelf/pool/AbstractPooledObject.java
@@ -22,9 +22,18 @@ package de.siegmar.logbackgelf.pool;
 public abstract class AbstractPooledObject {
 
     private final long createdAt = System.currentTimeMillis();
+    private long lastBorrowed = createdAt;
 
     final long lifeTime() {
         return System.currentTimeMillis() - createdAt;
+    }
+
+    final long lastBorrowed() {
+        return lastBorrowed;
+    }
+
+    final void borrow() {
+        this.lastBorrowed = System.currentTimeMillis();
     }
 
     protected void close() {

--- a/src/test/java/de/siegmar/logbackgelf/pool/SimpleObjectPoolTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/pool/SimpleObjectPoolTest.java
@@ -40,7 +40,7 @@ public class SimpleObjectPoolTest {
     @Test
     public void simple() throws InterruptedException {
         final SimpleObjectPool<MyPooledObject> pool =
-            new SimpleObjectPool<>(factory, 2, 100, 100);
+            new SimpleObjectPool<>(factory, 2, 100, 100, 100);
 
         for (int i = 0; i < 10; i++) {
             final MyPooledObject o1 = pool.borrowObject();
@@ -56,7 +56,7 @@ public class SimpleObjectPoolTest {
     @Test
     public void invalidate() throws InterruptedException {
         final SimpleObjectPool<MyPooledObject> pool =
-            new SimpleObjectPool<>(factory, 2, 100, 100);
+            new SimpleObjectPool<>(factory, 2, 100, 100, 100);
 
         final MyPooledObject o1 = pool.borrowObject();
         assertEquals(1, o1.getId());
@@ -65,6 +65,28 @@ public class SimpleObjectPoolTest {
         final MyPooledObject o2 = pool.borrowObject();
         assertEquals(2, o2.getId());
         pool.returnObject(o2);
+
+        final MyPooledObject o3 = pool.borrowObject();
+        assertEquals(3, o3.getId());
+        pool.returnObject(o3);
+    }
+
+    @Test
+    public void maxLastBorrowed() throws InterruptedException {
+        final SimpleObjectPool<MyPooledObject> pool =
+                new SimpleObjectPool<>(factory, 1, 100, 100, 0);
+
+        final MyPooledObject o1 = pool.borrowObject();
+        assertEquals(1, o1.getId());
+        pool.returnObject(o1);
+
+        Thread.sleep(2);
+
+        final MyPooledObject o2 = pool.borrowObject();
+        assertEquals(2, o2.getId());
+        pool.returnObject(o2);
+
+        Thread.sleep(2);
 
         final MyPooledObject o3 = pool.borrowObject();
         assertEquals(3, o3.getId());


### PR DESCRIPTION
When connections remain open without being used, they may be
considered stale by the server and closed. This can lead to log messages
failing with

java.lang.SocketException: broken pipe

This commit introduces a maximum 'idle time' for pooled connections. If
a connection has not been used within that time, it will be considered
stale and not reused. By default, this new feature is disabled.

I'm interested to hear your thoughts on this PR, and happy to make changes and adjustments if you need me to. We have been experiencing a bug where many of our log messages failed to arrive in graylog and tracked the problem down to the server ELB max idle time. This PR is intended to help us recycle connections if they have not been used recently, but to avoid recycling them if they have been used recently.