### PR TITLE
Fieldmapper improvements

### DIFF
--- a/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
@@ -279,7 +279,7 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
         }
         if (!VALID_ADDITIONAL_FIELD_PATTERN.matcher(fieldName).matches()) {
             throw new IllegalArgumentException("fieldName key '" + fieldName + "' is illegal. "
-                + "Keys must apply to regex ^[\\w.-]*$");
+                + "Keys must apply to regex " + VALID_ADDITIONAL_FIELD_PATTERN);
         }
 
         if (dst.get(fieldName) != null) {

--- a/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
@@ -282,11 +282,10 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
                 + "Keys must apply to regex " + VALID_ADDITIONAL_FIELD_PATTERN);
         }
 
-        if (dst.get(fieldName) != null) {
+        final Object oldValue = dst.putIfAbsent(fieldName, convertToNumberIfNeeded(fieldValue));
+        if (oldValue != null) {
             throw new IllegalArgumentException("Field mapper tried to set already defined key '" + fieldName + "'.");
         }
-
-        dst.put(fieldName, convertToNumberIfNeeded(fieldValue));
     }
 
     private Object convertToNumberIfNeeded(final Object value) {


### PR DESCRIPTION
Two small improvement suggestions (related to issue #55):
-  Include the actual pattern constant in the exception message, to make sure they do not get out of sync
- Avoid map lookup for better performance
