### PR TITLE
Improve SimpleJsonEncoder.escapeString memory usage

### DIFF
--- a/src/main/java/de/siegmar/logbackgelf/SimpleJsonEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/SimpleJsonEncoder.java
@@ -107,7 +107,8 @@ class SimpleJsonEncoder implements Closeable {
      */
     @SuppressWarnings("checkstyle:cyclomaticcomplexity")
     private void escapeString(final String str) throws IOException {
-        for (final char ch : str.toCharArray()) {
+        for (int i = 0; i < str.length(); i++) {
+            final char ch = str.charAt(i);
             switch (ch) {
                 case QUOTE:
                 case '\\':


### PR DESCRIPTION
write String slices instead of single chars to the Writer. Iterate over the string to be escaped and write a new slice every time a char needs to be escaped.