### PR TITLE
add configurable socket timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Find more advanced examples in the [examples directory](examples).
 * **encoder**: See Encoder configuration below.
 * **connectTimeout**: Maximum time (in milliseconds) to wait for establishing a connection. A value
   of 0 disables the connect timeout. Default: 15,000 milliseconds.
+* **socketTimeout**: Maximum time (in milliseconds) to block when reading a socket. A value of 0 disables
+  the socket timeout. Default: 5,000 milliseconds.
 * **reconnectInterval**: Time interval (in seconds) after an existing connection is closed and
   re-opened. A value of -1 disables automatic reconnects. Default: 60 seconds.
 * **maxRetries**: Number of retries. A value of 0 disables retry attempts. Default: 2.

--- a/examples/advanced_tcp.xml
+++ b/examples/advanced_tcp.xml
@@ -4,6 +4,7 @@
         <graylogHost>localhost</graylogHost>
         <graylogPort>12201</graylogPort>
         <connectTimeout>15000</connectTimeout>
+        <socketTimeout>5000</socketTimeout>
         <reconnectInterval>300</reconnectInterval>
         <maxRetries>2</maxRetries>
         <retryDelay>3000</retryDelay>

--- a/examples/advanced_tcp_tls.xml
+++ b/examples/advanced_tcp_tls.xml
@@ -4,6 +4,7 @@
         <graylogHost>localhost</graylogHost>
         <graylogPort>12201</graylogPort>
         <connectTimeout>15000</connectTimeout>
+        <socketTimeout>5000</socketTimeout>
         <reconnectInterval>300</reconnectInterval>
         <maxRetries>2</maxRetries>
         <retryDelay>3000</retryDelay>

--- a/src/main/java/de/siegmar/logbackgelf/GelfTcpAppender.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfTcpAppender.java
@@ -26,6 +26,7 @@ import de.siegmar.logbackgelf.pool.SimpleObjectPool;
 public class GelfTcpAppender extends AbstractGelfAppender {
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 15_000;
+    private static final int DEFAULT_SOCKET_TIMEOUT = 0;
     private static final int DEFAULT_RECONNECT_INTERVAL = 60;
     private static final int DEFAULT_MAX_RETRIES = 2;
     private static final int DEFAULT_RETRY_DELAY = 3_000;
@@ -38,6 +39,12 @@ public class GelfTcpAppender extends AbstractGelfAppender {
      * the connect timeout. Default: 15,000 milliseconds.
      */
     private int connectTimeout = DEFAULT_CONNECT_TIMEOUT;
+
+    /**
+     * Maximum time (in milliseconds) to block when reading a socket. A value of 0 disables the socket timeout.
+     * Default: {@value DEFAULT_SOCKET_TIMEOUT}
+     */
+    private int socketTimeout = DEFAULT_SOCKET_TIMEOUT;
 
     /**
      * Time interval (in seconds) after an existing connection is closed and re-opened.
@@ -82,6 +89,14 @@ public class GelfTcpAppender extends AbstractGelfAppender {
 
     public void setConnectTimeout(final int connectTimeout) {
         this.connectTimeout = connectTimeout;
+    }
+
+    public int getSocketTimeout() {
+        return socketTimeout;
+    }
+
+    public void setSocketTimeout(int socketTimeout) {
+        this.socketTimeout = socketTimeout;
     }
 
     public int getReconnectInterval() {
@@ -136,7 +151,7 @@ public class GelfTcpAppender extends AbstractGelfAppender {
         final AddressResolver addressResolver = new AddressResolver(getGraylogHost());
 
         connectionPool = new SimpleObjectPool<>(() -> new TcpConnection(initSocketFactory(),
-            addressResolver, getGraylogPort(), connectTimeout),
+            addressResolver, getGraylogPort(), connectTimeout, socketTimeout),
             poolSize, poolMaxWaitTime, reconnectInterval, poolMaxIdleTime);
     }
 

--- a/src/main/java/de/siegmar/logbackgelf/GelfTcpAppender.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfTcpAppender.java
@@ -26,7 +26,7 @@ import de.siegmar.logbackgelf.pool.SimpleObjectPool;
 public class GelfTcpAppender extends AbstractGelfAppender {
 
     private static final int DEFAULT_CONNECT_TIMEOUT = 15_000;
-    private static final int DEFAULT_SOCKET_TIMEOUT = 0;
+    private static final int DEFAULT_SOCKET_TIMEOUT = 5_000;
     private static final int DEFAULT_RECONNECT_INTERVAL = 60;
     private static final int DEFAULT_MAX_RETRIES = 2;
     private static final int DEFAULT_RETRY_DELAY = 3_000;
@@ -42,7 +42,7 @@ public class GelfTcpAppender extends AbstractGelfAppender {
 
     /**
      * Maximum time (in milliseconds) to block when reading a socket. A value of 0 disables the socket timeout.
-     * Default: {@value DEFAULT_SOCKET_TIMEOUT}
+     * Default: {@value DEFAULT_SOCKET_TIMEOUT} milliseconds.
      */
     private int socketTimeout = DEFAULT_SOCKET_TIMEOUT;
 
@@ -95,7 +95,7 @@ public class GelfTcpAppender extends AbstractGelfAppender {
         return socketTimeout;
     }
 
-    public void setSocketTimeout(int socketTimeout) {
+    public void setSocketTimeout(final int socketTimeout) {
         this.socketTimeout = socketTimeout;
     }
 

--- a/src/main/java/de/siegmar/logbackgelf/TcpConnection.java
+++ b/src/main/java/de/siegmar/logbackgelf/TcpConnection.java
@@ -35,16 +35,19 @@ public class TcpConnection extends AbstractPooledObject {
     private final SocketFactory socketFactory;
     private final int port;
     private final int connectTimeout;
+    private final int socketTimeout;
 
     private volatile OutputStream outputStream;
 
     TcpConnection(final SocketFactory socketFactory,
-                  final AddressResolver addressResolver, final int port, final int connectTimeout) {
+                  final AddressResolver addressResolver, final int port, final int connectTimeout,
+                  final int socketTimeout) {
 
         this.addressResolver = addressResolver;
         this.socketFactory = socketFactory;
         this.port = port;
         this.connectTimeout = connectTimeout;
+        this.socketTimeout = socketTimeout;
     }
 
     public void write(final byte[] messageToSend) throws IOException {
@@ -62,6 +65,7 @@ public class TcpConnection extends AbstractPooledObject {
 
     private void connect() throws IOException {
         final Socket socket = socketFactory.createSocket();
+        socket.setSoTimeout(socketTimeout);
         final InetAddress ip = addressResolver.resolve();
         socket.connect(new InetSocketAddress(ip, port), connectTimeout);
         outputStream = socket.getOutputStream();

--- a/src/test/resources/tcp-config.xml
+++ b/src/test/resources/tcp-config.xml
@@ -4,6 +4,7 @@
         <graylogHost>localhost</graylogHost>
         <graylogPort>12201</graylogPort>
         <connectTimeout>15000</connectTimeout>
+        <socketTimeout>5000</socketTimeout>
         <reconnectInterval>300</reconnectInterval>
         <maxRetries>2</maxRetries>
         <retryDelay>3000</retryDelay>

--- a/src/test/resources/tcp_tls-config.xml
+++ b/src/test/resources/tcp_tls-config.xml
@@ -4,6 +4,7 @@
         <graylogHost>localhost</graylogHost>
         <graylogPort>12201</graylogPort>
         <connectTimeout>15000</connectTimeout>
+        <socketTimeout>5000</socketTimeout>
         <reconnectInterval>300</reconnectInterval>
         <maxRetries>2</maxRetries>
         <retryDelay>3000</retryDelay>


### PR DESCRIPTION
Adds a configurable socket timeout to the GelfTcpAppender.
As described in #62 the current socket timeout is 0 (no timeout), so this is the default value for compatibility.

Perhaps the socket timeout should be implemented in GelfTcp**Tls**Appender instead. I'm not sure, if it makes sense for a non-tls appender, since reading the socket appears when performing the tls handshake.