### PR TITLE
Update logback to 1.4.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 group = "de.siegmar"
-version = "4.0.2"
+version = "5.0.0"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
     withJavadocJar()
     withSourcesJar()
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    api 'ch.qos.logback:logback-classic:1.2.9'
+    api 'ch.qos.logback:logback-classic:1.4.11'
     testImplementation(platform('org.junit:junit-bom:5.7.0'))
     testImplementation('org.junit.jupiter:junit-jupiter')
     testImplementation 'com.google.guava:guava:31.0.1-jre'

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.siegmar</groupId>
     <artifactId>logback-gelf</artifactId>
-    <version>4.0.2</version>
+    <version>5.0.0</version>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.9</version>
+            <version>1.4.11</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -392,7 +392,7 @@ public class GelfEncoderTest {
         final Logger logger = lc.getLogger(LOGGER_NAME);
 
         final LoggingEvent event = simpleLoggingEvent(logger, null);
-        event.setMarker(MarkerFactory.getMarker("SINGLE"));
+        event.addMarker(MarkerFactory.getMarker("SINGLE"));
 
         final String logMsg = encodeToStr(event);
 
@@ -413,7 +413,7 @@ public class GelfEncoderTest {
         final LoggingEvent event = simpleLoggingEvent(logger, null);
         final Marker marker = MarkerFactory.getMarker("FIRST");
         marker.add(MarkerFactory.getMarker("SECOND"));
-        event.setMarker(marker);
+        event.addMarker(marker);
 
         final String logMsg = encodeToStr(event);
 


### PR DESCRIPTION
As a preparation for some future pull-requests regarding new featues in slf4j 2.0 this pull-requests updates the dependencies to the latest version and updates the required java version to 11.
