### PR TITLE
Support for multiple markers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 group = "de.siegmar"
-version = "4.0.2"
+version = "5.0.0"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
     withJavadocJar()
     withSourcesJar()
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    api 'ch.qos.logback:logback-classic:1.2.9'
+    api 'ch.qos.logback:logback-classic:1.4.11'
     testImplementation(platform('org.junit:junit-bom:5.7.0'))
     testImplementation('org.junit.jupiter:junit-jupiter')
     testImplementation 'com.google.guava:guava:31.0.1-jre'

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.siegmar</groupId>
     <artifactId>logback-gelf</artifactId>
-    <version>4.0.2</version>
+    <version>5.0.0</version>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.9</version>
+            <version>1.4.11</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/siegmar/logbackgelf/mappers/MarkerFieldMapper.java
+++ b/src/main/java/de/siegmar/logbackgelf/mappers/MarkerFieldMapper.java
@@ -20,11 +20,14 @@
 package de.siegmar.logbackgelf.mappers;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.slf4j.Marker;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+
 
 public class MarkerFieldMapper extends AbstractFixedNameFieldMapper<String> {
 
@@ -34,8 +37,16 @@ public class MarkerFieldMapper extends AbstractFixedNameFieldMapper<String> {
 
     @Override
     protected Optional<String> getValue(final ILoggingEvent event) {
-        return Optional.ofNullable(event.getMarker())
-            .map(MarkerFieldMapper::buildMarkerStr);
+        final List<Marker> markerList = event.getMarkerList();
+
+        if (markerList == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(markerList.stream()
+                        .map(MarkerFieldMapper::buildMarkerStr)
+                .collect(Collectors.joining(", "))
+        );
     }
 
     private static String buildMarkerStr(final Marker marker) {

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -414,13 +414,14 @@ public class GelfEncoderTest {
         final Marker marker = MarkerFactory.getMarker("FIRST");
         marker.add(MarkerFactory.getMarker("SECOND"));
         event.addMarker(marker);
+        event.addMarker(MarkerFactory.getMarker("THIRD"));
 
         final String logMsg = encodeToStr(event);
 
         final ObjectMapper om = new ObjectMapper();
         final JsonNode jsonNode = om.readTree(logMsg);
         coreValidation(jsonNode);
-        assertEquals("FIRST, SECOND", jsonNode.get("_marker").textValue());
+        assertEquals("FIRST, SECOND, THIRD", jsonNode.get("_marker").textValue());
     }
 
     private String encodeToStr(final LoggingEvent event) {

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -392,7 +392,7 @@ public class GelfEncoderTest {
         final Logger logger = lc.getLogger(LOGGER_NAME);
 
         final LoggingEvent event = simpleLoggingEvent(logger, null);
-        event.setMarker(MarkerFactory.getMarker("SINGLE"));
+        event.addMarker(MarkerFactory.getMarker("SINGLE"));
 
         final String logMsg = encodeToStr(event);
 
@@ -413,7 +413,7 @@ public class GelfEncoderTest {
         final LoggingEvent event = simpleLoggingEvent(logger, null);
         final Marker marker = MarkerFactory.getMarker("FIRST");
         marker.add(MarkerFactory.getMarker("SECOND"));
-        event.setMarker(marker);
+        event.addMarker(marker);
 
         final String logMsg = encodeToStr(event);
 

--- a/src/test/java/de/siegmar/logbackgelf/mappers/MarkerFieldMapperTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/mappers/MarkerFieldMapperTest.java
@@ -1,0 +1,60 @@
+/*
+ * Logback GELF - zero dependencies Logback GELF appender library.
+ * Copyright (C) 2016 Oliver Siegmar
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package de.siegmar.logbackgelf.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+
+class MarkerFieldMapperTest {
+    private final MarkerFieldMapper markerFieldMapper = new MarkerFieldMapper("marker");
+
+    @Test
+    void multipleMarkers() {
+        final LoggingEvent loggingEvent = new LoggingEvent();
+        final Marker first = MarkerFactory.getMarker("first");
+        first.add(MarkerFactory.getMarker("reference"));
+        loggingEvent.addMarker(first);
+        loggingEvent.addMarker(MarkerFactory.getMarker("second"));
+
+        final Map<String, String> result = new HashMap<>();
+        markerFieldMapper.mapField(loggingEvent, result::put);
+
+        assertEquals(1, result.size());
+        assertEquals("first, reference, second", result.get("marker"));
+    }
+
+    @Test
+    void noMarkers() {
+        final LoggingEvent loggingEvent = new LoggingEvent();
+
+        final Map<String, String> result = new HashMap<>();
+        markerFieldMapper.mapField(loggingEvent, result::put);
+
+        assertEquals(0, result.size());
+    }
+}


### PR DESCRIPTION
Since slf4j 2.0 multiple markers are supported directly without references.
This pull request adds support for this new feature while supporting the old way.

Should be reviewed / merged after https://github.com/osiegmar/logback-gelf/pull/94