### PR TITLE
Support for Key value pairs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 group = "de.siegmar"
-version = "4.0.2"
+version = "5.0.0"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(8)
+        languageVersion = JavaLanguageVersion.of(11)
     }
     withJavadocJar()
     withSourcesJar()
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    api 'ch.qos.logback:logback-classic:1.2.9'
+    api 'ch.qos.logback:logback-classic:1.4.11'
     testImplementation(platform('org.junit:junit-bom:5.7.0'))
     testImplementation('org.junit.jupiter:junit-jupiter')
     testImplementation 'com.google.guava:guava:31.0.1-jre'

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -207,7 +207,9 @@
 
         <!-- Checks for Metrics - http://checkstyle.sf.net/config_metrics.html -->
         <module name="BooleanExpressionComplexity"/>
-        <module name="ClassDataAbstractionCoupling"/>
+        <module name="ClassDataAbstractionCoupling">
+            <property name="max" value="8"/>
+        </module>
         <module name="ClassFanOutComplexity"/>
         <module name="CyclomaticComplexity"/>
         <module name="NPathComplexity"/>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.siegmar</groupId>
     <artifactId>logback-gelf</artifactId>
-    <version>4.0.2</version>
+    <version>5.0.0</version>
     <dependencies>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.2.9</version>
+            <version>1.4.11</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
@@ -35,6 +35,7 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.util.LevelToSyslogSeverity;
 import ch.qos.logback.core.encoder.EncoderBase;
 import de.siegmar.logbackgelf.mappers.CallerDataFieldMapper;
+import de.siegmar.logbackgelf.mappers.KeyValuePairFieldMapper;
 import de.siegmar.logbackgelf.mappers.MarkerFieldMapper;
 import de.siegmar.logbackgelf.mappers.MdcDataFieldMapper;
 import de.siegmar.logbackgelf.mappers.RootExceptionDataFieldMapper;
@@ -86,6 +87,11 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
      * If true, the log level name (e.g. DEBUG) will be sent, too. Default: false.
      */
     private boolean includeLevelName;
+
+    /**
+     * If true, the key value pairs from a log event will be sent, too. Default: false.
+     */
+    private boolean includeEventKeyValuesPairs;
 
     /**
      * The key that should be used for the levelName.
@@ -188,6 +194,14 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
 
     public void setIncludeLevelName(final boolean includeLevelName) {
         this.includeLevelName = includeLevelName;
+    }
+
+    public boolean isIncludeEventKeyValuesPairs() {
+        return includeEventKeyValuesPairs;
+    }
+
+    public void setIncludeEventKeyValuesPairs(final boolean includeEventKeyValuesPairs) {
+        this.includeEventKeyValuesPairs = includeEventKeyValuesPairs;
     }
 
     public String getLevelNameKey() {
@@ -337,6 +351,10 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
 
         if (includeLevelName) {
             builtInFieldMappers.add(new SimpleFieldMapper<>(levelNameKey, event -> event.getLevel().toString()));
+        }
+
+        if (includeEventKeyValuesPairs) {
+            builtInFieldMappers.add(new KeyValuePairFieldMapper());
         }
 
         if (includeRawMessage) {

--- a/src/main/java/de/siegmar/logbackgelf/mappers/KeyValuePairFieldMapper.java
+++ b/src/main/java/de/siegmar/logbackgelf/mappers/KeyValuePairFieldMapper.java
@@ -1,0 +1,41 @@
+/*
+ * Logback GELF - zero dependencies Logback GELF appender library.
+ * Copyright (C) 2016 Oliver Siegmar
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package de.siegmar.logbackgelf.mappers;
+
+import java.util.List;
+import java.util.function.BiConsumer;
+
+import org.slf4j.event.KeyValuePair;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import de.siegmar.logbackgelf.GelfFieldMapper;
+
+
+public class KeyValuePairFieldMapper implements GelfFieldMapper<String> {
+
+    @Override
+    public void mapField(final ILoggingEvent event, final BiConsumer<String, String> valueHandler) {
+        final List<KeyValuePair> keyValuePairList = event.getKeyValuePairs();
+
+        if (keyValuePairList != null) {
+            keyValuePairList.forEach(p -> valueHandler.accept(p.key, String.valueOf(p.value)));
+        }
+    }
+}

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -392,7 +392,7 @@ public class GelfEncoderTest {
         final Logger logger = lc.getLogger(LOGGER_NAME);
 
         final LoggingEvent event = simpleLoggingEvent(logger, null);
-        event.setMarker(MarkerFactory.getMarker("SINGLE"));
+        event.addMarker(MarkerFactory.getMarker("SINGLE"));
 
         final String logMsg = encodeToStr(event);
 
@@ -413,7 +413,7 @@ public class GelfEncoderTest {
         final LoggingEvent event = simpleLoggingEvent(logger, null);
         final Marker marker = MarkerFactory.getMarker("FIRST");
         marker.add(MarkerFactory.getMarker("SECOND"));
-        event.setMarker(marker);
+        event.addMarker(marker);
 
         final String logMsg = encodeToStr(event);
 

--- a/src/test/java/de/siegmar/logbackgelf/mappers/KeyValuePairFieldMapperTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/mappers/KeyValuePairFieldMapperTest.java
@@ -1,0 +1,60 @@
+/*
+ * Logback GELF - zero dependencies Logback GELF appender library.
+ * Copyright (C) 2018 Oliver Siegmar
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package de.siegmar.logbackgelf.mappers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.event.KeyValuePair;
+
+import ch.qos.logback.classic.spi.LoggingEvent;
+
+
+class KeyValuePairFieldMapperTest {
+
+    private final KeyValuePairFieldMapper keyValuePairFieldMapper = new KeyValuePairFieldMapper();
+
+    @Test
+    void keyValuePairsAreMapped() {
+        final LoggingEvent loggingEvent = new LoggingEvent();
+        loggingEvent.addKeyValuePair(new KeyValuePair("first", "value"));
+        loggingEvent.addKeyValuePair(new KeyValuePair("second", 1));
+
+        final Map<String, String> result = new HashMap<>();
+        keyValuePairFieldMapper.mapField(loggingEvent, result::put);
+
+        assertEquals("value", result.get("first"));
+        assertEquals("1", result.get("second"));
+    }
+
+    @Test
+    void nullDoesNotThrownAnError() {
+
+        final LoggingEvent loggingEvent = new LoggingEvent();
+
+        final Map<String, String> result = new HashMap<>();
+        keyValuePairFieldMapper.mapField(loggingEvent, result::put);
+
+        assertEquals(0, result.size());
+    }
+}


### PR DESCRIPTION
Support for adding key-value-pairs to the gelf message.
The feature is disabled by default and can be enabled by setting includeEventKeyValuesPairs=true.

Should be reviewed / merged after https://github.com/osiegmar/logback-gelf/pull/94