### PR TITLE
encoder uses layout for all message formating, but still prevents bla…

### DIFF
--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -444,7 +444,7 @@ class GelfEncoderTest {
 
     @ParameterizedTest
     @ValueSource(strings = { " \t ", "", "\n" })
-    void blankShortMessage(String message) {
+    void blankShortMessage(final String message) {
         encoder.start();
 
         final LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -482,4 +482,12 @@ class GelfEncoderTest {
         assertThat(encoder.getFieldMappers()).containsExactly(fieldMapper);
     }
 
+    @Test
+    void hasDefaultPatternLayout() {
+        encoder.start();
+
+        assertThat(encoder.getFullMessageLayout()).isNotNull();
+        assertThat(encoder.getShortMessageLayout()).isNotNull();
+    }
+
 }

--- a/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfEncoderTest.java
@@ -121,20 +121,6 @@ class GelfEncoderTest {
     }
 
     @Test
-    void shortenShortMessageDefault() {
-        final String expectedShortMessage = "A".repeat(250);
-        final String actualShortMessage = "  " + expectedShortMessage + "123\r\n";
-
-
-        final GelfEncoder gelfEncoder = new GelfEncoder();
-        gelfEncoder.setMaxShortMessageLength(250);
-
-        assertThat(gelfEncoder.normalizeShortMessage(actualShortMessage))
-            .hasSameSizeAs(expectedShortMessage)
-            .isEqualTo(expectedShortMessage);
-    }
-
-    @Test
     void exception() {
         encoder.start();
 
@@ -456,18 +442,19 @@ class GelfEncoderTest {
             .isNotEqualTo("unknown");
     }
 
-    @Test
-    void blankShortmessage() {
+    @ParameterizedTest
+    @ValueSource(strings = { " \t ", "", "\n" })
+    void blankShortMessage(String message) {
         encoder.start();
 
         final LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
         final Logger logger = lc.getLogger(LOGGER_NAME);
 
-        final LoggingEvent event = new LoggingEvent(LOGGER_NAME, logger, Level.DEBUG, " \t ", null, new Object[]{1});
+        final LoggingEvent event = new LoggingEvent(LOGGER_NAME, logger, Level.DEBUG, message, null, new Object[]{1});
         final String logMsg = encodeToStr(event);
 
         assertThatJson(logMsg).node("short_message")
-            .isEqualTo("Empty message replaced by logback-gelf");
+            .isEqualTo("Blank message replaced by logback-gelf");
     }
 
     @Test

--- a/src/test/resources/tcp-config.xml
+++ b/src/test/resources/tcp-config.xml
@@ -19,12 +19,12 @@
             <includeCallerData>false</includeCallerData>
             <includeRootCauseData>false</includeRootCauseData>
             <includeLevelName>false</includeLevelName>
-            <shortPatternLayout class="ch.qos.logback.classic.PatternLayout">
+            <shortMessageLayout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>%m%nopex</pattern>
-            </shortPatternLayout>
-            <fullPatternLayout class="ch.qos.logback.classic.PatternLayout">
+            </shortMessageLayout>
+            <fullMessageLayout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>%m%n</pattern>
-            </fullPatternLayout>
+            </fullMessageLayout>
             <numbersAsString>false</numbersAsString>
             <staticField>app_name:backend</staticField>
             <staticField>os_arch:${os.arch}</staticField>

--- a/src/test/resources/tcp_tls-config.xml
+++ b/src/test/resources/tcp_tls-config.xml
@@ -19,12 +19,12 @@
             <includeCallerData>false</includeCallerData>
             <includeRootCauseData>false</includeRootCauseData>
             <includeLevelName>false</includeLevelName>
-            <shortPatternLayout class="ch.qos.logback.classic.PatternLayout">
+            <shortMessageLayout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>%m%nopex</pattern>
-            </shortPatternLayout>
-            <fullPatternLayout class="ch.qos.logback.classic.PatternLayout">
+            </shortMessageLayout>
+            <fullMessageLayout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>%m%n</pattern>
-            </fullPatternLayout>
+            </fullMessageLayout>
             <numbersAsString>false</numbersAsString>
             <staticField>app_name:backend</staticField>
             <staticField>os_arch:${os.arch}</staticField>

--- a/src/test/resources/udp-config.xml
+++ b/src/test/resources/udp-config.xml
@@ -14,12 +14,12 @@
             <includeCallerData>false</includeCallerData>
             <includeRootCauseData>false</includeRootCauseData>
             <includeLevelName>false</includeLevelName>
-            <shortPatternLayout class="ch.qos.logback.classic.PatternLayout">
+            <shortMessageLayout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>%m%nopex</pattern>
-            </shortPatternLayout>
-            <fullPatternLayout class="ch.qos.logback.classic.PatternLayout">
+            </shortMessageLayout>
+            <fullMessageLayout class="ch.qos.logback.classic.PatternLayout">
                 <pattern>%m%n</pattern>
-            </fullPatternLayout>
+            </fullMessageLayout>
             <numbersAsString>false</numbersAsString>
             <staticField>app_name:backend</staticField>
             <staticField>os_arch:${os.arch}</staticField>


### PR DESCRIPTION
Fixes #100

> Formatting the message itself (including shortening, trimming, etc.) should be the sole responsibility of the pattern layout. Only the blank string handling has to be addresses – as you pointed out.

API-Breaks:
- removed `maxShortMessageLength` from `GelfEncoder`,  has to be configured by the user with a suitable `Layout`
- renamed `shortPatternLayout` to `shortMessageLayout`
- renamed `fullPatternLayout` to `fullMessageLayout`