### PR TITLE
Add toggle-feature for logging only first marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Find more advanced examples in the [examples directory](examples).
 * **shortMessageLayout**: Short message format. Default: `"%m%nopex"`.
 * **fullMessageLayout**: Full message format (Stacktrace). Default: `"%m%n"`.
 * **numbersAsString**: Log numbers as String. Default: false.
+* **soloMarker**: Log only the first marker. Default: false.
 * **staticFields**: Additional, static fields to send to graylog. Defaults: none.
 
 ## Troubleshooting

--- a/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfEncoder.java
@@ -41,6 +41,7 @@ import de.siegmar.logbackgelf.mappers.MarkerFieldMapper;
 import de.siegmar.logbackgelf.mappers.MdcDataFieldMapper;
 import de.siegmar.logbackgelf.mappers.RootExceptionDataFieldMapper;
 import de.siegmar.logbackgelf.mappers.SimpleFieldMapper;
+import de.siegmar.logbackgelf.mappers.SoloMarkerFieldMapper;
 
 /**
  * This class is responsible for transforming a Logback log event to a GELF message.
@@ -133,6 +134,11 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
      * Log numbers as String. Default: false.
      */
     private boolean numbersAsString;
+
+    /**
+     * Log only the first marker. Default: false.
+     */
+    private boolean soloMarker;
 
     /**
      * Additional, static fields to send to graylog. Defaults: none.
@@ -245,6 +251,14 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
 
     public void setNumbersAsString(final boolean numbersAsString) {
         this.numbersAsString = numbersAsString;
+    }
+
+    public boolean isSoloMarker() {
+        return soloMarker;
+    }
+
+    public void setSoloMarker(boolean soloMarker) {
+        this.soloMarker = soloMarker;
     }
 
     public Layout<ILoggingEvent> getShortMessageLayout() {
@@ -373,7 +387,7 @@ public class GelfEncoder extends EncoderBase<ILoggingEvent> {
         }
 
         if (includeMarker) {
-            builtInFieldMappers.add(new MarkerFieldMapper("marker"));
+            builtInFieldMappers.add(soloMarker ? new SoloMarkerFieldMapper("marker") : new MarkerFieldMapper("marker"));
         }
 
         if (includeMdcData) {

--- a/src/main/java/de/siegmar/logbackgelf/mappers/SoloMarkerFieldMapper.java
+++ b/src/main/java/de/siegmar/logbackgelf/mappers/SoloMarkerFieldMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Logback GELF - zero dependencies Logback GELF appender library.
+ * Copyright (C) 2016 Oliver Siegmar
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+package de.siegmar.logbackgelf.mappers;
+
+import java.util.Optional;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.slf4j.Marker;
+
+public class SoloMarkerFieldMapper extends AbstractFixedNameFieldMapper<String> {
+
+    public SoloMarkerFieldMapper(final String fieldName) {
+        super(fieldName);
+    }
+
+    @Override
+    protected Optional<String> getValue(final ILoggingEvent event) {
+        return Optional.ofNullable(event.getMarker())
+                .map(Marker::getName);
+    }
+}


### PR DESCRIPTION
## Proposed Changes

- Add toggle-feature for GelfEncoder to log only first marker
This change introduces a toggle-feature allowing the GelfEncoder to log only the first marker. 
This feature aims to enhance flexibility and performance for users who require simplified marker logging.

