### PR TITLE
Update build.gradle.kts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.1.1] - 2025-02-01
+### Changed
+- Update dependency to logback 1.5.15
+
 ## [6.1.0] - 2024-09-05
 ### Added
 - Support for external encoders like Spring's StructuredLogEncoder

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dependencies.
 ## Requirements
 
 - Java 11
-- Logback 1.5.7
+- Logback 1.5.15
 
 ## Examples
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    api("ch.qos.logback:logback-classic:1.5.7")
+    api("ch.qos.logback:logback-classic:1.5.15")
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.assertj:assertj-core:3.26.3")


### PR DESCRIPTION
Fixes #

Logback dependency pulls some annoying CVE-2024-12798 up to 1.5.13 that likes to popup on some scanners.

