### PR TITLE
feat: adds Basic Auth and Authorization Header to Gelf-Http-Appender

### DIFF
--- a/examples/advanced_http.xml
+++ b/examples/advanced_http.xml
@@ -8,6 +8,10 @@
         <maxRetries>2</maxRetries>
         <retryDelay>3000</retryDelay>
         <compressionMethod>GZIP</compressionMethod>
+        <basicAuthUsername>testUser</basicAuthUsername>
+        <basicAuthPassword>testPassword</basicAuthPassword>
+        <authorizationHeaderName>X-API-TOKEN</authorizationHeaderName>
+        <authorizationHeaderValue>X-API-TOKEN-VALUE</authorizationHeaderValue>
         <encoder class="de.siegmar.logbackgelf.GelfEncoder">
             <originHost>localhost</originHost>
             <includeRawMessage>false</includeRawMessage>

--- a/src/main/java/de/siegmar/logbackgelf/GelfHttpAppender.java
+++ b/src/main/java/de/siegmar/logbackgelf/GelfHttpAppender.java
@@ -31,6 +31,7 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.time.Duration;
+import java.util.Base64;
 import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
@@ -91,6 +92,29 @@ public class GelfHttpAppender extends UnsynchronizedAppenderBase<ILoggingEvent> 
     /**
      * The encoder to use for encoding log messages.
      */
+
+    /**
+     * Username for HTTP Basic Authentication.
+     */
+    private String basicAuthUsername;
+
+    /**
+     * Password for HTTP Basic Authentication.
+     */
+    private String basicAuthPassword;
+
+    /**
+     * The name for the authorization header to use.
+     */
+
+    private String authorizationHeaderName;
+
+    /**
+     * The secret authorization header value.
+     */
+
+    private String authorizationHeaderValue;
+
     private Encoder<ILoggingEvent> encoder;
 
     private Compressor compressor;
@@ -141,6 +165,38 @@ public class GelfHttpAppender extends UnsynchronizedAppenderBase<ILoggingEvent> 
 
     public void setRetryDelay(final int retryDelay) {
         this.retryDelay = retryDelay;
+    }
+
+    public String getBasicAuthUsername() {
+        return basicAuthUsername;
+    }
+
+    public void setBasicAuthUsername(final String basicAuthUsername) {
+        this.basicAuthUsername = basicAuthUsername;
+    }
+
+    public String getBasicAuthPassword() {
+        return basicAuthPassword;
+    }
+
+    public void setBasicAuthPassword(final String basicAuthPassword) {
+        this.basicAuthPassword = basicAuthPassword;
+    }
+
+    public String getAuthorizationHeaderName() {
+        return authorizationHeaderName;
+    }
+
+    public void setAuthorizationHeaderName(final String authorizationHeaderName) {
+        this.authorizationHeaderName = authorizationHeaderName;
+    }
+
+    public String getAuthorizationHeaderValue() {
+        return authorizationHeaderValue;
+    }
+
+    public void setAuthorizationHeaderValue(final String authorizationHeaderValue) {
+        this.authorizationHeaderValue = authorizationHeaderValue;
     }
 
     public CompressionMethod getCompressionMethod() {
@@ -233,6 +289,18 @@ public class GelfHttpAppender extends UnsynchronizedAppenderBase<ILoggingEvent> 
 
         contentEncoding()
             .ifPresent(encoding -> reqB.header("Content-Encoding", encoding));
+
+        // Add Basic Authentication if username and password are provided
+        if (basicAuthUsername != null && basicAuthPassword != null) {
+            final String auth = basicAuthUsername + ":" + basicAuthPassword;
+            final String encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
+            reqB.header("Authorization", "Basic " + encodedAuth);
+        }
+
+        // Add Authentication Header if name and value are provided
+        if (authorizationHeaderName != null && authorizationHeaderValue != null) {
+            reqB.header(authorizationHeaderName, authorizationHeaderValue);
+        }
 
         return reqB
             .POST(HttpRequest.BodyPublishers.ofByteArray(data))

--- a/src/test/java/de/siegmar/logbackgelf/GelfHttpAppenderTest.java
+++ b/src/test/java/de/siegmar/logbackgelf/GelfHttpAppenderTest.java
@@ -19,8 +19,7 @@
 
 package de.siegmar.logbackgelf;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static java.net.HttpURLConnection.HTTP_ACCEPTED;
 import static net.javacrumbs.jsonunit.assertj.JsonAssertions.assertThatJson;
 import static org.awaitility.Awaitility.await;
@@ -68,7 +67,13 @@ class GelfHttpAppenderTest {
     }
 
     private static RequestPattern gelfRequest() {
-        return WIRE_MOCK.stubFor(post("/gelf").willReturn(aResponse().withStatus(HTTP_ACCEPTED)))
+        String username = "testUser";
+        String password = "testPassword";
+
+        return WIRE_MOCK.stubFor(post("/gelf")
+                .withBasicAuth(username, password)
+                .withHeader("X-API-TOKEN", equalTo("X-API-TOKEN-VALUE"))
+                .willReturn(aResponse().withStatus(HTTP_ACCEPTED)))
             .getRequest();
     }
 
@@ -98,6 +103,10 @@ class GelfHttpAppenderTest {
         gelfAppender.setName("GELF");
         gelfAppender.setUri(String.format("http://localhost:%d/gelf", WIRE_MOCK.getPort()));
         gelfAppender.setEncoder(gelfEncoder);
+        gelfAppender.setBasicAuthUsername("testUser");
+        gelfAppender.setBasicAuthPassword("testPassword");
+        gelfAppender.setAuthorizationHeaderName("X-API-TOKEN");
+        gelfAppender.setAuthorizationHeaderValue("X-API-TOKEN-VALUE");
         gelfAppender.start();
         return gelfAppender;
     }

--- a/src/test/resources/http-config.xml
+++ b/src/test/resources/http-config.xml
@@ -8,6 +8,10 @@
         <maxRetries>2</maxRetries>
         <retryDelay>3000</retryDelay>
         <compressionMethod>GZIP</compressionMethod>
+        <basicAuthUsername>testUser</basicAuthUsername>
+        <basicAuthPassword>testPassword</basicAuthPassword>
+        <authorizationHeaderName>X-API-TOKEN</authorizationHeaderName>
+        <authorizationHeaderValue>X-API-TOKEN-VALUE</authorizationHeaderValue>
         <encoder class="de.siegmar.logbackgelf.GelfEncoder">
             <originHost>localhost</originHost>
             <includeRawMessage>false</includeRawMessage>


### PR DESCRIPTION
As described in https://github.com/osiegmar/logback-gelf/issues/114 this PR adds Basic Auth and Authorization Header to Gelf-Http-Appender.

This is useful for authentication if the Graylog-Server is public available.